### PR TITLE
[libpinyin] define _GNU_SOURCE for getline()

### DIFF
--- a/src/eim.cpp
+++ b/src/eim.cpp
@@ -18,6 +18,8 @@
  *   51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.              *
  ***************************************************************************/
 
+#define _GNU_SOURCE
+
 #include <sstream>
 #include <stdlib.h>
 #include <stdio.h>


### PR DESCRIPTION
getline() requires _GNU_SOURCE to be defined on some platforms
