### PR TITLE
Small fixes for the Qt5 port

### DIFF
--- a/dictmanager/CMakeLists.txt
+++ b/dictmanager/CMakeLists.txt
@@ -15,7 +15,6 @@ if (ENABLE_QT)
 find_package(Qt5 5.7 REQUIRED COMPONENTS Core Gui WebEngineWidgets Network DBus)
 find_package(FcitxQt5WidgetsAddons REQUIRED)
 find_package(FcitxQt5DBusAddons REQUIRED)
-pkg_check_modules(FCITX_QT "fcitx-qt>=4.2.8" REQUIRED )
 endif (ENABLE_QT)
 
 if (NOT ENABLE_QT)

--- a/dictmanager/browserdialog.ui
+++ b/dictmanager/browserdialog.ui
@@ -37,9 +37,9 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>QWebView</class>
+   <class>QWebEngineView</class>
    <extends>QWidget</extends>
-   <header>QtWebKit/QWebView</header>
+   <header>QtWebEngineWidgets/QWebEngineView</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/dictmanager/dictmanager.h
+++ b/dictmanager/dictmanager.h
@@ -22,7 +22,7 @@
 #define FCITX_DICTMANAGER_H
 
 #include <QMainWindow>
-#include <fcitx-qt/fcitxqtconfiguiwidget.h>
+#include <fcitxqtconfiguiwidget.h>
 #include "ui_dictmanager.h"
 
 class ErrorOverlay;

--- a/dictmanager/importer.h
+++ b/dictmanager/importer.h
@@ -22,7 +22,7 @@
 #define FCITX_IMPORTER_H
 
 #include <QString>
-#include <fcitx-qt/fcitxqtconnection.h>
+#include <fcitxqtconnection.h>
 
 class QDBusInterface;
 class QDBusPendingCallWatcher;


### PR DESCRIPTION
This makes it possible to build fcitx-libpinyin properly with Qt5.